### PR TITLE
Update Chatbar for the user to Only Be as Long As the Length of the Text Instead of the Entire Width of Chat

### DIFF
--- a/pages/chatbot.module.css
+++ b/pages/chatbot.module.css
@@ -184,6 +184,8 @@
   box-shadow: inset 0 2px 8px rgba(255, 182, 230, 0.2);
   margin-bottom: 1.5rem;
   scroll-behavior: smooth;
+  display: flex;
+  flex-direction: column;
 }
 
 .chatBox::-webkit-scrollbar {
@@ -236,9 +238,12 @@
   border-radius: 20px 20px 8px 20px;
   border: 2px solid var(--button-border, #ff69b4);
   box-shadow: 0 4px 16px rgba(255, 105, 180, 0.15);
-  align-self: flex-end;
   text-align: right;
   line-height: 1.4;
+  max-width: 60%;
+  margin-left: auto;
+  margin-right: 0;
+  display:inline-block;
 }
 
 .questionBubble h2 {


### PR DESCRIPTION
This is a bug fix that I'm currently fixing. When the user types in the chat, the chat length will only be as long as the user's text:
<img width="1042" alt="Screenshot 2025-06-29 at 7 11 24 PM" src="https://github.com/user-attachments/assets/bfe8abde-42c2-4475-b529-0fc2b0bd2680" />
