### PR TITLE
Fix Buttons to Have Thin Poppins Style on All Pages

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -21,7 +21,7 @@ export default function App({ Component, pageProps }: AppProps) {
      <ClerkProvider publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}>
     <>
     <header className="header">
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@900&display=swap" rel="stylesheet"/>
+    <link href="https://fonts.googleapis.com/css2?family=Tiny5&family=VT323&family=Poppins:wght@400;600;700&display=swap" rel="stylesheet"/>
       <div className="header-left">
         <button
           className="mobile-menu"


### PR DESCRIPTION
I finally figurd out how to have the Thin Poppins Style that we wanted on All pages.
Here's the design:
<img width="546" alt="Screenshot 2025-06-30 at 4 36 06 PM" src="https://github.com/user-attachments/assets/7c4112fd-cfc5-430a-8926-2465df375eb2" />
Here's what it looks like now:
<img width="594" alt="Screenshot 2025-07-07 at 2 11 46 PM" src="https://github.com/user-attachments/assets/d7ce15f5-61da-4649-9d63-6b8e04c7ddd6" />
