### PR TITLE
Fix Text Wrapping Issue in Question Bubble

### DIFF
--- a/pages/chatbot.module.css
+++ b/pages/chatbot.module.css
@@ -346,11 +346,12 @@
   box-shadow: 0 4px 16px rgba(255, 105, 180, 0.15);
   text-align: right;
   line-height: 1.4;
-  max-width: 60%;
+  max-width: 80%;
   margin-left: auto;
   margin-right: 0;
   margin-bottom: 1rem;
-  display:inline-block;
+  display:block;
+  word-break: break-word;
 }
 
 .questionBubble .messageHeader {


### PR DESCRIPTION
When you clicked on the trending topics, the text wrapping would be a bit off. Let's fix that. 