### PR TITLE
Move trending questions inside of chatbox

### DIFF
--- a/pages/chatbot.tsx
+++ b/pages/chatbot.tsx
@@ -334,6 +334,19 @@ export default function Chatbot() {
                     </div>
                   </div>
                 )}
+                {showHero && (
+                      <div>
+                        <h3 className={styles.quickStartTitle}>Try these popular questions:</h3>
+                        <div className={styles.questionButtonContainer}>
+                          {questionsToShow.map((question, idx) => (
+                            <button key={idx} onClick={() => sendMessage(question)}
+                              className={styles.questionButton}>
+                              {question}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    )}
               </div>
 
               {/* Image Preview */}
@@ -382,20 +395,6 @@ export default function Chatbot() {
                 </button>
               </div>
             </div>
-
-            {/* Quick Start Questions */}
-            {showHero && (
-              <div className={styles.quickStartSection}>
-                <h3 className={styles.quickStartTitle}>Try these popular questions:</h3>
-                <div className={styles.questionButtonContainer}>
-                  {questionsToShow.map((question, idx) => (
-                    <button key = {idx} onClick={() => sendMessage(question)}
-                    className={styles.questionButton}>
-                    {question}
-                  </button>
-                 ))} </div>
-              </div>
-            )}
           </div>
         </main>
 


### PR DESCRIPTION
This was requested based on the design:
<img width="844" height="189" alt="Screenshot 2025-07-13 at 3 43 35 PM" src="https://github.com/user-attachments/assets/bc912648-f42e-4fe4-a71f-035ae1462253" />
Here's how it looks now:

<img width="1060" height="507" alt="Screenshot 2025-07-13 at 3 42 12 PM" src="https://github.com/user-attachments/assets/d19e9cb0-4540-4604-9829-136fbe350fd1" />
