### PR TITLE
updates to room generator header and subheader

### DIFF
--- a/pages/room.module.css
+++ b/pages/room.module.css
@@ -1,7 +1,7 @@
 /* Page Container */
 .pageContainer {
   min-height: 100vh;
-  font-family: 'Press Start 2P', 'VT323', 'Tiny5', 'Courier New', Courier, monospace;
+  font-family: 'VT323', 'Tiny5', 'Courier New', Courier, monospace;
   position: relative;
 }
 
@@ -62,7 +62,7 @@
 }
 
 .headerTitle {
-  font-size: 4rem;
+  font-size: 4.8rem;
   color: #f91b8f;
   margin: 0;
   letter-spacing: 2px;
@@ -70,10 +70,10 @@
 }
 
 .headerText {
-  font-size: 1.3rem;
+  font-size: 1.2rem;
   font-family: 'Roboto Mono', monospace;
   color: #ff69b4;
-  margin-top: 0.4rem;
+  margin-top: 0.05rem;
   margin-bottom: 1rem;
   font-weight: 900;
   letter-spacing: 0.5px;
@@ -109,7 +109,7 @@
 .subheaderList,
 .subheaderRightImage {
   flex: 1;
-  padding: 2rem;
+  padding: 1.2rem;
   box-sizing: border-box;
 }
 .subheaderList ul {
@@ -131,7 +131,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  padding: 0.8rem;
   flex-direction: column;
 }
 
@@ -139,7 +139,7 @@
   max-width: 100%;
   height: auto;
   border-radius: 16px;
-  border: 3px solid var(--button-border, #ff69b4);
+  border: 1.5px solid var(--button-border, #ff69b4);
   margin-bottom: 1rem;
 }
 

--- a/pages/room.tsx
+++ b/pages/room.tsx
@@ -570,13 +570,13 @@ export default function Room() {
       {loading && showMinigame && <DinoGameModal show={loading} onClose={() => setShowMinigame(false)} />}
       <div style={{
         width: '100%',
-        padding: '2.2rem 0 0.7rem 0',
+        padding: '0.1rem 0 0.5rem 0',
         textAlign: 'center',
         zIndex: 200,
         position: 'relative',
       }}>
         <h1 className={styles.headerTitle} style={{
-          fontFamily: "'Press Start 2P', Tiny5, Courier New, Courier, monospace",
+          fontFamily: "VT323, Tiny5, Courier New, Courier, monospace",
         }}>
           ROOM GENERATOR
         </h1>
@@ -584,178 +584,473 @@ export default function Room() {
         >
           Upload your space, describe your dream, and watch the magic happen.
         </div>
-        <h2 className={styles.headerTitle} style={{
-          fontFamily: "'Press Start 2P', Tiny5, Courier New, Courier, monospace",
-          fontSize: "2rem",
-        }}>
-          ✨ SEE THE MAGIC IN ACTION ✨
-        </h2>
-        <div className={styles.headerText} style={{
-          fontSize: "1.2rem"
-        }}>
-          Real transformations, real results - your space could be next!
-        </div>
       </div>
       <div>
+        {/* Feature Bubbles */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'center',
+          gap: '1.5rem',
+          marginBottom: '1rem',
+          flexWrap: 'wrap',
+        }}>
+          <div style={{
+            padding: '1rem 1.5rem',
+            background: '#fff',
+            borderRadius: '16px',
+            border: '3px solid #f91b8f',
+            boxShadow: '0 4px 16px rgba(255, 105, 180, 0.15)',
+            maxWidth: '340px',
+            transition: 'all 0.3s ease',
+            cursor: 'pointer',
+            transform: 'translateY(0) scale(1)',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.transform = 'translateY(-8px) scale(1.05)';
+            e.currentTarget.style.boxShadow = '0 12px 32px rgba(255, 105, 180, 0.3)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.transform = 'translateY(0) scale(1)';
+            e.currentTarget.style.boxShadow = '0 4px 16px rgba(255, 105, 180, 0.15)';
+          }}>
+            <div style={{
+              fontFamily: "VT323, Tiny5, Courier, monospace",
+              fontSize: '1.6rem',
+              color: '#f91b8f',
+              fontWeight: 700,
+              marginBottom: '0.5rem',
+              lineHeight: '1.4',
+              textAlign: 'center',
+            }}>
+              🎨 AI-POWERED DESIGN
+            </div>
+            <div style={{
+              fontFamily: 'Roboto Mono, monospace',
+              fontSize: '0.8rem',
+              color: '#b8005c',
+              lineHeight: '1.4',
+              textAlign: 'center',
+            }}>
+              Smart algorithms create personalized room layouts
+            </div>
+          </div>
+          
+          <div style={{
+            padding: '1rem 1.5rem',
+            background: '#fff',
+            borderRadius: '16px',
+            border: '3px solid #f91b8f',
+            boxShadow: '0 4px 16px rgba(255, 105, 180, 0.15)',
+            maxWidth: '340px',
+            transition: 'all 0.3s ease',
+            cursor: 'pointer',
+            transform: 'translateY(0) scale(1)',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.transform = 'translateY(-8px) scale(1.05)';
+            e.currentTarget.style.boxShadow = '0 12px 32px rgba(255, 105, 180, 0.3)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.transform = 'translateY(0) scale(1)';
+            e.currentTarget.style.boxShadow = '0 4px 16px rgba(255, 105, 180, 0.15)';
+          }}>
+            <div style={{
+              fontFamily: "VT323, Tiny5, Courier, monospace",
+              fontSize: '1.6rem',
+              color: '#f91b8f',
+              fontWeight: 700,
+              marginBottom: '0.5rem',
+              lineHeight: '1.4',
+              textAlign: 'center',
+            }}>
+              ⚡ INSTANT RESULTS
+            </div>
+            <div style={{
+              fontFamily: 'Roboto Mono, monospace',
+              fontSize: '0.8rem',
+              color: '#b8005c',
+              lineHeight: '1.4',
+              textAlign: 'center',
+            }}>
+              Generate beautiful rooms in seconds
+            </div>
+          </div>
+          
+          <div style={{
+            padding: '1rem 1.5rem',
+            background: '#fff',
+            borderRadius: '16px',
+            border: '3px solid #f91b8f',
+            boxShadow: '0 4px 16px rgba(255, 105, 180, 0.15)',
+            maxWidth: '340px',
+            transition: 'all 0.3s ease',
+            cursor: 'pointer',
+            transform: 'translateY(0) scale(1)',
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.transform = 'translateY(-8px) scale(1.05)';
+            e.currentTarget.style.boxShadow = '0 12px 32px rgba(255, 105, 180, 0.3)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.transform = 'translateY(0) scale(1)';
+            e.currentTarget.style.boxShadow = '0 4px 16px rgba(255, 105, 180, 0.15)';
+          }}>
+            <div style={{
+              fontFamily: "VT323, Tiny5, Courier, monospace",
+              fontSize: '1.6rem',
+              color: '#f91b8f',
+              fontWeight: 700,
+              marginBottom: '0.5rem',
+              lineHeight: '1.4',
+              textAlign: 'center',
+            }}>
+              💡 SMART SUGGESTIONS
+            </div>
+            <div style={{
+              fontFamily: 'Roboto Mono, monospace',
+              fontSize: '0.8rem',
+              color: '#b8005c',
+              lineHeight: '1.4',
+              textAlign: 'center',
+            }}>
+              Get product recommendations based on your room
+            </div>
+          </div>
+        </div>
+        
         {/* Subheader section */}
         <div style={{
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'stretch',
           gap: '2rem',
-          maxWidth: '1200px',
-          margin: '2.5rem auto',
+          maxWidth: '800px',
+          margin: '1.5rem auto',
           flexWrap: 'wrap',
         }}>
-          {/* Left Window */}
-          <section className={styles.subheaderWindow}>
-            <div style={{
-              flex: 1.2,
-              padding: '2rem',
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              alignItems: 'flex-start',
-            }}>
-              <ul className={styles.subheaderList} style={{
-                fontFamily: "'Roboto Mono', 'Press Start 2P', Tiny5, Courier New, Courier, monospace",
-                listStyle: 'none',
-                padding: 0,
-                margin: 0,
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'space-evenly',
-                gap: '1.6rem',
-              }}>
-                <li style={{ margin: 0 }}>
-                  <span style={{fontFamily: "'Press Start 2P', Tiny5, Courier, monospace"
-                  }}>🎨 AI-POWERED DESIGN - </span>
-                  Smart algorithms create personalized room layouts</li>
-                <li style={{ margin: 0 }}>
-                  <span style={{fontFamily: "'Press Start 2P', Tiny5, Courier, monospace"}}>⚡ INSTANT RESULTS - </span> 
-                  Generate beautiful rooms in seconds</li>
-                <li style={{ margin: 0 }}>
-                  <span style={{fontFamily: "'Press Start 2P', Tiny5, Courier, monospace"
-                  }}>💡 SMART SUGGESTIONS - </span> 
-                  Get product recommendations based on your room</li>
-              </ul>
-            </div>
-            
-            {/* Dynamic Arrow */}
+          {/* Window */}
+          <section style={{
+            flex: 1,
+            minWidth: '340px',
+            background: '#ffc9ea',
+            border: '2.5px solid #f91b8f',
+            borderRadius: '18px',
+            boxShadow: '0 4px 24px #ffb6e6, 0 8px 32px rgba(182,182,255,0.13)',
+            outlineOffset: '-6px',
+            position: 'relative',
+            transition: 'box-shadow 0.2s',
+            overflow: 'hidden',
+            marginBottom: '0.2rem',
+            display: 'flex',
+            flexDirection: 'column',
+            minHeight: '360px',
+            height: '100%',
+          }}>
+            {/* Window Title Bar */}
             <div style={{
               display: 'flex',
+              justifyContent: 'space-between',
               alignItems: 'center',
-              justifyContent: 'center',
-              padding: '0 1rem',
-              position: 'relative',
+              background: '#f91b84',
+              borderBottom: '2px solid #f91b8f',
+              padding: '8px 20px',
+              fontFamily: "Roboto Mono, monospace",
+              fontSize: '16px',
+              fontWeight: 600,
+              color: '#ffffff',
+              boxShadow: '0 2px 12px rgba(255, 105, 180, 0.15)',
             }}>
               <div style={{
-                fontSize: '3rem',
-                color: '#f91b8f',
-                animation: 'arrowSlide 1s infinite',
-                filter: 'drop-shadow(0 0 8px #ffb6e6)',
-                transform: 'rotate(0deg)',
-              }}>
-                →
-              </div>
-              <style>{`
-                @keyframes arrowSlide { 
-                  0%, 100% { 
-                    transform: translateX(0); 
-                  }
-                  50% { 
-                    transform: translateX(12px); 
-                  }
-                }
-              `}</style>
-            </div>
-            
-            {/* example image */}
-            <div className={styles.subheaderRightImage}>
-              <label style={{fontFamily: "'Roboto Mono', Tiny5, Courier, monospace", marginBottom: '1rem', textAlign: 'center'}}>
-              ✨ Toggle for room transformation magic ✨</label>
-              
-              <div style={{
-                position: 'relative',
                 display: 'flex',
-                justifyContent: 'center',
-                marginBottom: '1rem',
+                alignItems: 'center',
+                gap: '10px',
+                fontWeight: 700,
+                letterSpacing: '1px',
+                textShadow: '0 0 8px rgba(255, 182, 230, 0.5)',
               }}>
-                {/* Image */}
-                <img
-                src={isToggled ? '/after-room-3.png' : '/before-room-3.png'}
-                alt="Before/After"
-                className={styles.rightImage}
-                style={{ margin: 0 }}
-                />
-                
-                {/* Tag bubbles and toggle under the image */}
+                DORM ROOM GLOW UP
+              </div>
+              <div className="window-controls">
+                <button className="window-buttons" title="Minimize"><span className="window-button-icon">─</span></button>
+                <button className="window-buttons" title="Maximize"><span className="window-button-icon">□</span></button>
+                <button className="window-buttons" title="Close"><span className="window-button-icon">×</span></button>
+              </div>
+            </div>
+            {/* Window Content */}
+            <div style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'row',
+              minHeight: '260px',
+              height: '100%',
+            }}>
+              
+              {/* example image */}
+              <div className={styles.subheaderRightImage}>
                 <div style={{
-                  position: 'absolute',
-                  bottom: '-2.2rem',
-                  left: '0',
-                  right: '0',
+                  display: 'flex',
+                  gap: '0.4rem',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                }}>
+                  {/* Before Image */}
+                  <div style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'flex-start',
+                    gap: '0.3rem',
+                    position: 'relative',
+                  }}>
+                    <img
+                      src="/before-room-3.png"
+                      alt="Before"
+                      className={styles.rightImage}
+                      style={{ 
+                        margin: 0,
+                        width: '400px',
+                        height: '220px',
+                        objectFit: 'cover',
+                      }}
+                    />
+                    {/* Tag bubbles for Before image */}
+                    <div style={{
+                      display: 'flex',
+                      gap: '0.3rem',
+                    }}>
+                      <span style={{
+                        background: '#ffa6d4',
+                        color: '#f91b8f',
+                        fontSize: '0.7rem',
+                        fontWeight: 700,
+                        padding: '0.2rem 0.5rem',
+                        borderRadius: '16px',
+                        fontFamily: 'Roboto Mono, monospace',
+                        letterSpacing: '0.5px',
+                      }}>
+                        COZY
+                      </span>
+                      <span style={{
+                        color: '#f91b8f',
+                        fontSize: '0.7rem',
+                        fontWeight: 700,
+                        padding: '0.2rem 0.5rem',
+                        borderRadius: '16px',
+                        fontFamily: 'Roboto Mono, monospace',
+                        letterSpacing: '0.5px',
+                      }}>
+                        NATURAL
+                      </span>
+                    </div>
+                  </div>
+                  
+                  {/* After Image */}
+                  <div style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'flex-end',
+                    gap: '0.3rem',
+                    position: 'relative',
+                  }}>
+                    <img
+                      src="/after-room-3.png"
+                      alt="After"
+                      className={styles.rightImage}
+                      style={{ 
+                        margin: 0,
+                        width: '400px',
+                        height: '220px',
+                        objectFit: 'cover',
+                      }}
+                    />
+                    {/* 30 SEC indicator for After image */}
+                    <div style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '0.3rem',
+                    }}>
+                      <span style={{
+                        color: '#f91b8f',
+                        fontSize: '0.7rem',
+                        fontWeight: 700,
+                        padding: '0.3rem 0.4rem',
+                        borderRadius: '16px',
+                        fontFamily: 'Roboto Mono, monospace',
+                        letterSpacing: '0.5px',
+                      }}>
+                        🔥 30 SEC
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                
+                {/* Statistics Section */}
+                <div style={{
                   display: 'flex',
                   justifyContent: 'space-between',
                   alignItems: 'center',
+                  marginTop: '0.8rem',
+                  padding: '0.8rem',
+                  background: '#ffc9ea',
+                  borderRadius: '16px',
+                  border: '2px solid #f91b8f',
+                  boxShadow: '0 4px 16px rgba(249, 27, 143, 0.1)',
+                  width: '100%',
+                  maxWidth: '900px',
+                  marginLeft: 'auto',
+                  marginRight: 'auto',
                 }}>
-                  {/* Tag bubbles on the left */}
-                  <div style={{
-                    display: 'flex',
-                    gap: '0.5rem',
-                    minWidth: '120px', // Reserve space for bubbles
-                  }}>
-                    {isToggled && (
-                      <>
-                        <span style={{
-                          padding: '0.3rem 0.6rem',
-                          background: '#ffe0f2',
-                          color: '#f91b8f',
-                          borderRadius: '16px',
-                          fontSize: '0.6rem',
-                          fontFamily: 'Roboto Mono, monospace',
-                          fontWeight: 600,
-                          border: '1px solid #ff69b4',
-                        }}>
-                          cozy
-                        </span>
-                        <span style={{
-                          padding: '0.3rem 0.6rem',
-                          background: '#e0eaff',
-                          color: '#5baefc',
-                          borderRadius: '16px',
-                          fontSize: '0.6rem',
-                          fontFamily: 'Roboto Mono, monospace',
-                          fontWeight: 600,
-                          border: '1px solid #5baefc',
-                        }}>
-                          peaceful
-                        </span>
-                      </>
-                    )}
-                  </div>
-                  
-                  {/* Toggle on the right */}
                   <div style={{
                     display: 'flex',
                     flexDirection: 'column',
                     alignItems: 'center',
-                    gap: '0.3rem',
+                    textAlign: 'center',
+                    flex: 1,
                   }}>
-                    <label className={styles.switch} style={{
-                      transform: 'scale(0.7)',
+                    <div style={{
+                      fontSize: '1.8rem',
+                      fontWeight: 900,
+                      color: '#f91b8f',
+                      fontFamily: 'Roboto Mono, monospace',
+                      marginBottom: '0.3rem',
                     }}>
-                      <input type="checkbox" checked={isToggled} onChange={handleToggle} />
-                      <span className={styles.slider}></span>
-                    </label>
+                      10,000+
+                    </div>
+                    <div style={{
+                      fontSize: '0.8rem',
+                      color: '#b8005c',
+                      fontFamily: 'Roboto Mono, monospace',
+                      fontWeight: 600,
+                    }}>
+                      Rooms Transformed
+                    </div>
+                  </div>
+                  
+                  <div style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    textAlign: 'center',
+                    flex: 1,
+                  }}>
+                    <div style={{
+                      fontSize: '1.8rem',
+                      fontWeight: 900,
+                      color: '#f91b8f',
+                      fontFamily: 'Roboto Mono, monospace',
+                      marginBottom: '0.3rem',
+                    }}>
+                      98%
+                    </div>
+                    <div style={{
+                      fontSize: '0.8rem',
+                      color: '#b8005c',
+                      fontFamily: 'Roboto Mono, monospace',
+                      fontWeight: 600,
+                    }}>
+                      Love Their Results
+                    </div>
+                  </div>
+                  
+                  <div style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    textAlign: 'center',
+                    flex: 1,
+                  }}>
+                    <div style={{
+                      fontSize: '1.8rem',
+                      fontWeight: 900,
+                      color: '#f91b8f',
+                      fontFamily: 'Roboto Mono, monospace',
+                      marginBottom: '0.3rem',
+                    }}>
+                      30 SEC
+                    </div>
+                    <div style={{
+                      fontSize: '0.8rem',
+                      color: '#b8005c',
+                      fontFamily: 'Roboto Mono, monospace',
+                      fontWeight: 600,
+                    }}>
+                      Average Generation Time
+                    </div>
                   </div>
                 </div>
+                
+                <style>{`
+                  @keyframes arrowSlide { 
+                    0%, 100% { 
+                      transform: translateX(0); 
+                    }
+                    50% { 
+                      transform: translateX(8px); 
+                    }
+                  }
+                `}</style>
               </div>
             </div>
           </section>
         </div>
 
+        {/* Start Your Transformation Button */}
         <div style={{
+          display: 'flex',
+          justifyContent: 'center',
+          marginTop: '0.2rem',
+          marginBottom: '2rem',
+        }}>
+          <button
+            style={{
+              padding: '1.5rem 3rem',
+              background: '#f91b8f',
+              color: '#fff',
+              fontFamily: 'Roboto Mono, monospace',
+              fontSize: '1.3rem',
+              fontWeight: 800,
+              border: 'none',
+              borderRadius: '16px',
+              boxShadow: '0 8px 32px #ffd6f7',
+              cursor: 'pointer',
+              letterSpacing: '1px',
+              transition: 'all 0.3s ease',
+              position: 'relative',
+              overflow: 'hidden',
+            }}
+            onMouseEnter={e => {
+              e.currentTarget.style.transform = 'translateY(-4px) scale(1.05)';
+              e.currentTarget.style.boxShadow = '0 12px 40px #ffd6f7';
+            }}
+            onMouseLeave={e => {
+              e.currentTarget.style.transform = 'translateY(0) scale(1)';
+              e.currentTarget.style.boxShadow = '0 8px 32px #ffd6f7';
+            }}
+            onClick={() => {
+              // Scroll to the two windows section
+              const windowsSection = document.querySelector('#upload-section');
+              if (windowsSection) {
+                windowsSection.scrollIntoView({ 
+                  behavior: 'smooth',
+                  block: 'start'
+                });
+              }
+            }}
+          >
+            <span style={{
+              position: 'absolute',
+              top: 10,
+              left: 16,
+              zIndex: 2,
+              display: 'flex',
+              alignItems: 'center',
+            }}>
+              <Sparkles style={{ color: '#fff6fa', width: 28, height: 28 }} />
+            </span>
+            Start Your Transformation
+          </button>
+        </div>
+
+        <div id="upload-section" style={{
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'stretch',
@@ -789,7 +1084,7 @@ export default function Room() {
               alignItems: 'center',
               background: '#f91b84',
               borderBottom: '2px solid #f91b8f',
-              padding: '12px 20px',
+              padding: '8px 20px',
               fontFamily: "Roboto Mono, monospace",
               fontSize: '16px',
               fontWeight: 600,
@@ -1138,7 +1433,7 @@ export default function Room() {
               alignItems: 'center',
               background: '#f91b84',
               borderBottom: '2px solid #f91b8f',
-              padding: '12px 20px',
+              padding: '8px 20px',
               fontFamily: "Roboto Mono, monospace",
               fontSize: '16px',
               fontWeight: 600,
@@ -1385,7 +1680,7 @@ export default function Room() {
             margin: '0 0 0.4rem 0',
             fontWeight: 800,
             letterSpacing: '2px',
-            fontFamily: "'Press Start 2P', 'Tiny5', 'Courier New', Courier, monospace",
+            fontFamily: "VT323, 'Tiny5', 'Courier New', Courier, monospace",
           }}>GLOW UP GALLERY</div>
           <div style={{
                     fontFamily: 'Roboto Mono, monospace',


### PR DESCRIPTION
I updated the top of the room gen page to match the lovable. 
There are several changes:

1. Header font: Press Start 2P -> VT323 (matches chatbot font)
2. Description section ("AI powered design...") -> moved to 3 feature bubbles under subtitle
3. Example before/after image: -> moved to new window underneath bubbles, no toggle button anymore

Additions:

1. Statistics section under example image
2. "Start Transformation" button that autoscrolls to upload image window