### PR TITLE
design fixes for chatbot

### DIFF
--- a/components/home/HeroSection.tsx
+++ b/components/home/HeroSection.tsx
@@ -29,7 +29,7 @@ export function HeroSection() {
       icon: MessageCircle,
       path: '/chatbot',
     },
-    { id: 'room', label: 'Room Generator', icon: Sparkles, path: '/room' },
+    { id: 'room', label: 'Room Makeover', icon: Sparkles, path: '/room' },
     {
       id: 'shop',
       label: 'Shop Toolkits',

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,7 +23,7 @@ const navItems = [
     icon: MessageCircle,
     path: '/chatbot',
   },
-  { id: 'room', label: 'Room Generator', icon: Sparkles, path: '/room' },
+  { id: 'room', label: 'Room Makeover', icon: Sparkles, path: '/room' },
   {
     id: 'shop',
     label: 'Shop Toolkits',

--- a/pages/chatbot.module.css
+++ b/pages/chatbot.module.css
@@ -227,13 +227,15 @@
 }
 
 .heroSubtitle {
-  font-size: 1.8rem;
-  color: var(--chat-text, #b8005c);
-  margin: 0 0 2rem 0;
+  font-size: 1.2rem;
+  color: #ff69b4;
+  margin: 0 0 1.4rem 0;
   line-height: 1.4;
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
+  font-weight: 900;
+  letter-spacing: 0.5px;
 }
 
 .heroFeatures {
@@ -361,7 +363,7 @@
   box-shadow: 0 4px 16px rgba(255, 105, 180, 0.15);
   line-height: 1.6;
   align-self: flex-start;
-  margin-bottom: 1rem;
+  margin-bottom: 2rem;
 }
 
 .questionBubble {
@@ -518,7 +520,7 @@
 }
 
 .customizeButton {
-  padding: 0.8rem 1.5rem;
+  padding: 0.6rem 1rem;
   border-radius: 12px;
   background: var(
     --button-bg,
@@ -526,11 +528,36 @@
   );
   border: 2px solid var(--button-border, #ff69b4);
   color: var(--button-text, white);
-  font-size: 1.1rem;
+  font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
   box-shadow: 0 2px 8px rgba(255, 105, 180, 0.15);
   transition: all 0.3s ease;
+}
+
+/* Responsive sizing for customize buttons */
+@media (max-width: 768px) {
+  .customizeButton {
+    padding: 0.4rem 0.8rem;
+    font-size: 0.9rem;
+    border-radius: 10px;
+  }
+}
+
+@media (max-width: 700px) {
+  .customizeButton {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    border-radius: 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .customizeButton {
+    padding: 0.2rem 0.4rem;
+    font-size: 0.7rem;
+    border-radius: 6px;
+  }
 }
 
 .customizeButton:hover {
@@ -659,6 +686,12 @@
 
   .heroSubtitle {
     font-size: 1.4rem;
+    font-family: 'Roboto Mono', monospace;
+    color: #ff69b4;
+    margin-top: 0.05rem;
+    margin-bottom: 1rem;
+    font-weight: 900;
+    letter-spacing: 0.5px;
   }
 
   .heroFeatures {
@@ -733,7 +766,6 @@
 .customizeButton,
 .logoText,
 .heroTitle,
-.heroSubtitle,
 .quickStartTitle {
   font-family: 'VT323', 'Tiny5', 'Courier New', Courier, monospace !important;
 }
@@ -805,10 +837,9 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: linear-gradient(
-    135deg,
-    rgba(255, 200, 230, 0.95) 0%,
-    rgba(200, 210, 240, 0.95) 100%
+  background: var(
+    --chat-bg,
+    linear-gradient(135deg, #ff69b4 0%, #ff1493 100%)
   );
   border-bottom: 2px solid var(--button-border, #ff69b4);
   padding: 12px 20px;
@@ -819,6 +850,17 @@
   box-shadow: 0 2px 12px rgba(255, 105, 180, 0.15);
   border-radius: 16px 16px 0 0;
   backdrop-filter: blur(10px);
+}
+
+.windowTitle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-shadow: 0 0 8px rgba(255, 182, 230, 0.5);
+  flex: 1;
+  justify-content: flex-start;
 }
 
 .windowTitle {
@@ -887,4 +929,94 @@
   align-items: center;
   margin-left: auto;
   margin-right: 1.2rem; /* Add spacing before window controls */
+}
+
+/* Mobile Menu Styles */
+.mobileMenuButton {
+  display: none;
+  position: relative;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.mobileMenuToggle {
+  background: var(
+    --button-bg,
+    linear-gradient(135deg, #ff69b4 0%, #ff1493 100%)
+  );
+  border: 2px solid var(--button-border, #ff69b4);
+  color: var(--button-text, white);
+  padding: 0.4rem 0.6rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(255, 105, 180, 0.15);
+  transition: all 0.3s ease;
+}
+
+.mobileMenuToggle:hover {
+  background: var(
+    --button-bg,
+    linear-gradient(135deg, #ff1493 0%, #ff69b4 100%)
+  );
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(255, 105, 180, 0.25);
+}
+
+.mobileMenuDropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: white;
+  border: 2px solid var(--button-border, #ff69b4);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(255, 105, 180, 0.2);
+  z-index: 1000;
+  min-width: 140px;
+  margin-top: 0.5rem;
+  overflow: hidden;
+}
+
+.mobileMenuItem {
+  display: block;
+  width: 100%;
+  padding: 0.8rem 1rem;
+  background: none;
+  border: none;
+  text-align: left;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--button-text, #ff69b4);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border-bottom: 1px solid rgba(255, 105, 180, 0.1);
+}
+
+.mobileMenuItem:last-child {
+  border-bottom: none;
+}
+
+.mobileMenuItem:hover {
+  background: var(--chat-bubble, #ffe0f2);
+  color: var(--button-text, #ff69b4);
+}
+
+/* Hide desktop actions and show mobile menu on small screens */
+@media (max-width: 480px) {
+  .windowActions {
+    display: none;
+  }
+  
+  .mobileMenuButton {
+    display: block;
+    margin-right: 1rem;
+  }
+}
+
+/* Hide mobile menu on larger screens */
+@media (min-width: 481px) {
+  .mobileMenuButton {
+    display: none;
+  }
 }

--- a/pages/chatbot.tsx
+++ b/pages/chatbot.tsx
@@ -28,6 +28,7 @@ export default function Chatbot() {
   const [trendingTopics, setTrendingTopics] = useState<string[] | null>(null)
   const chatBoxRef = useRef<HTMLDivElement>(null)
   const [showChats, setShowChats] = useState<false | 'default' | 'save'>(false)
+  const [showMobileMenu, setShowMobileMenu] = useState(false)
   const { isSignedIn } = useUser()
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -229,7 +230,7 @@ export default function Chatbot() {
     <>
       <Head>
         <link
-          href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Tiny5&family=VT323&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Tiny5&family=Roboto+Mono:wght@400;700&family=VT323&display=swap"
           rel="stylesheet"
         />
       </Head>
@@ -242,7 +243,7 @@ export default function Chatbot() {
               <h2 className={styles.heroTitle}>
                 Handy Mandy&apos;s DIY Chatbot
               </h2>
-              <p className={styles.heroSubtitle}>
+              <p className={styles.heroSubtitle} style={{ fontFamily: 'Roboto Mono, monospace' }}>
                 Your 24/7 DIY Assistant 🤖✨ Get instant help with home
                 projects, decor ideas, and DIY tips. Just ask Mandy anything!
               </p>
@@ -270,7 +271,50 @@ export default function Chatbot() {
           <div className={styles.chatContainer}>
             {/* Window Title Bar - Always visible */}
             <div className={styles.windowTitleBar}>
+              {/* Mobile Menu Button - Left Side */}
+              <div className={styles.mobileMenuButton}>
+                <button
+                  className={styles.mobileMenuToggle}
+                  onClick={() => setShowMobileMenu(!showMobileMenu)}
+                >
+                  ☰
+                </button>
+                {showMobileMenu && (
+                  <div className={styles.mobileMenuDropdown}>
+                    <button
+                      className={styles.mobileMenuItem}
+                      onClick={() => {
+                        setShowSettings(true)
+                        setShowMobileMenu(false)
+                      }}
+                    >
+                      ⚙️ Customize
+                    </button>
+                    <button
+                      className={styles.mobileMenuItem}
+                      onClick={() => {
+                        setShowChats('default')
+                        setShowMobileMenu(false)
+                      }}
+                    >
+                      💬 Chats
+                    </button>
+                    <button
+                      className={styles.mobileMenuItem}
+                      onClick={() => {
+                        handleSaveChat()
+                        setShowMobileMenu(false)
+                      }}
+                    >
+                      💾 Save Chat
+                    </button>
+                  </div>
+                )}
+              </div>
+
               <div className={styles.windowTitle}>CHAT WITH MANDY</div>
+              
+              {/* Desktop Actions */}
               <div className={styles.windowActions}>
                 <button
                   className={styles.customizeButton}
@@ -300,6 +344,7 @@ export default function Chatbot() {
                   </span>
                 </button>
               </div>
+
               <div className={styles.windowControls}>
                 <button className={styles.windowButton} title="Minimize">
                   <span className={styles.windowButtonIcon}>─</span>
@@ -379,8 +424,8 @@ export default function Chatbot() {
                   </div>
                 )}
                 {showHero && (
-                  <div className="border-t-4 border-primary/30 pt-4">
-                    <h3 className="text-center text-pink-600 font-bold text-xl mb-4">
+                  <div className="border-t-4 border-primary/30 pt-2 mt-14 ">
+                    <h3 className="text-center text-pink-600 font-bold text-xl mb-2">
                       Try these popular questions:
                     </h3>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-4">
@@ -388,7 +433,7 @@ export default function Chatbot() {
                         <button
                           key={idx}
                           onClick={() => sendMessage(question)}
-                          className="text-lg p-4 border-2 border-pink-400 rounded-2xl text-pink-600 hover:bg-pink-50 transition-colors text-left"
+                          className="text-lg p-2 border-2 border-pink-400 rounded-2xl text-pink-600 hover:bg-pink-50 transition-colors text-center"
                         >
                           {question}
                         </button>

--- a/pages/components/CustomizePanel.tsx
+++ b/pages/components/CustomizePanel.tsx
@@ -38,13 +38,13 @@ const themes = {
   },
 
   sky: {
-    '--button-bg': 'linear-gradient(90deg, #5baefc 0%, #b6eaff 100%)',
+    '--button-bg': 'linear-gradient(90deg, #8ebeeb 0%, #b6eaff 100%)',
     '--button-text': '#1d37f5',
     '--button-border': '#1d37f5',
     '--chat-border': '#5baefc',
     '--user-bubble': '#1d37f5',
-    '--chat-bubble': '#5baefc',
-    '--chat-bg': 'linear-gradient(135deg, #5baefc 0%, #b6eaff 100%)',
+    '--chat-bubble': '#b6eaff',
+    '--chat-bg': 'linear-gradient(135deg, #8ebbeb 0%, #b6eaff 100%)',
     '--chat-text': '#1d37f5',
     '--chat-text-user': 'white',
   },

--- a/pages/room.tsx
+++ b/pages/room.tsx
@@ -258,7 +258,6 @@ function DinoGameModal({ show, onClose }: { show: boolean, onClose: () => void }
 
   if (!show) return null
 
-  // ...existing code...
   // Ensure 'After' image is shown by default
   const [showAfterImage, setShowAfterImage] = React.useState(true)
   return (
@@ -528,9 +527,6 @@ export default function Room() {
 
   // Update vision prompt when room type changes
   useEffect(() => {
-    // No longer auto-prefix vision with room type
-    // The vision input will remain as entered by the user
-    // ...existing code...
   }, [roomType, customRoomType, showCustomInput])
 
   const handleRoomTypeChange = (value: string) => {
@@ -721,7 +717,7 @@ export default function Room() {
             fontFamily: 'VT323, Tiny5, Courier New, Courier, monospace',
           }}
         >
-          ROOM GENERATOR
+          ROOM MAKEOVER
         </h1>
         <div className={styles.headerText}>
           Upload your space, describe your dream, and watch the magic happen.
@@ -1043,7 +1039,6 @@ export default function Room() {
                     >
                       <span
                         style={{
-                          background: '#ffb9e2',
                           color: '#f91b8f',
                           fontSize: '0.7rem',
                           fontWeight: 700,
@@ -1053,20 +1048,7 @@ export default function Room() {
                           letterSpacing: '0.5px',
                         }}
                       >
-                        COZY
-                      </span>
-                      <span
-                        style={{
-                          color: '#f91b8f',
-                          fontSize: '0.7rem',
-                          fontWeight: 700,
-                          padding: '0.2rem 0.5rem',
-                          borderRadius: '16px',
-                          fontFamily: 'Roboto Mono, monospace',
-                          letterSpacing: '0.5px',
-                        }}
-                      >
-                        NATURAL
+                        BEFORE
                       </span>
                     </div>
                   </div>
@@ -1092,7 +1074,7 @@ export default function Room() {
                         objectFit: 'cover',
                       }}
                     />
-                    {/* 30 SEC indicator for After image */}
+                    {/* Label for After image */}
                     <div
                       style={{
                         display: 'flex',
@@ -1103,6 +1085,7 @@ export default function Room() {
                       <span
                         style={{
                           color: '#f91b8f',
+                          background: '#ffb9e2',
                           fontSize: '0.7rem',
                           fontWeight: 700,
                           padding: '0.3rem 0.4rem',
@@ -1111,7 +1094,7 @@ export default function Room() {
                           letterSpacing: '0.5px',
                         }}
                       >
-                        🔥 30 SEC
+                        AFTER
                       </span>
                     </div>
                   </div>
@@ -1976,8 +1959,8 @@ export default function Room() {
                   onMouseLeave={e =>
                     (e.currentTarget.style.transform = 'scale(1)')
                   }
-                  onClick={handleGenerate}
-                  disabled={loading}
+                  onClick={handleDownload}
+                  disabled={!afterImage}
                 >
                   {/* Highlight overlay for 3D effect */}
                   <div className="absolute top-2 left-2 right-2 h-4 rounded-t-2xl bg-gradient-to-r from-white/20 to-white/10 pointer-events-none" />
@@ -1985,7 +1968,7 @@ export default function Room() {
                   {/* Inner glow for active state */}
                   <div className="absolute inset-3 rounded-2xl bg-white/5 animate-pulse pointer-events-none" />
                   
-                  {/* Sparkles icon */}
+                  {/* Download icon */}
                   <span className="absolute top-2.5 left-4 z-10 flex items-center">
                     <Download className="w-7 h-7 text-white drop-shadow-sm" />
                   </span>


### PR DESCRIPTION
Design and visual changes:

**Chatbot**
- Switched save chat, customize, and chats buttons to a menu on mobile, before the title bar looked too full
- tweaked the customizable color themes to make the messages more readable
- changed hero subtitle font to roboto mono to match room makeover page
- added more padding between the chat bubbles and the example questions

**Room Makeover**
- changed name from room generator to room makeover on all pages
- changed description tags under hero images to 'before' and 'after'
- fixed the download button, before it had handleGenerate on click so it would restart the transformation
